### PR TITLE
Add menu data models and loader service

### DIFF
--- a/MauiDragDrop/MauiDragDrop.csproj
+++ b/MauiDragDrop/MauiDragDrop.csproj
@@ -9,7 +9,9 @@
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 
-	<ItemGroup>
+  <ItemGroup>
+    <Compile Include="Models\**\*.cs" />
+    <Compile Include="Services\**\*.cs" />
 		<!-- Images -->
 		<MauiImage Include="Resources\Images\*" />
 		<MauiImage Update="Resources\Images\dotnet_bot.png" Resize="True" BaseSize="300,185" />

--- a/MauiDragDrop/Models/MenuData.cs
+++ b/MauiDragDrop/Models/MenuData.cs
@@ -1,0 +1,8 @@
+using System.Collections.ObjectModel;
+
+namespace MauiDragDrop.Models;
+
+public class MenuData
+{
+    public ObservableCollection<MenuItem> MenuItems { get; set; } = new();
+}

--- a/MauiDragDrop/Models/MenuItem.cs
+++ b/MauiDragDrop/Models/MenuItem.cs
@@ -1,0 +1,6 @@
+namespace MauiDragDrop.Models;
+
+public class MenuItem
+{
+    public string Text { get; set; } = string.Empty;
+}

--- a/MauiDragDrop/Services/MenuItemTemplateSelector.cs
+++ b/MauiDragDrop/Services/MenuItemTemplateSelector.cs
@@ -1,0 +1,19 @@
+using Microsoft.Maui.Controls;
+using MauiDragDrop.Models;
+
+namespace MauiDragDrop.Services;
+
+public class MenuItemTemplateSelector : DataTemplateSelector
+{
+    public DataTemplate? DefaultTemplate { get; set; }
+    public DataTemplate? FormTemplate { get; set; }
+
+    protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+    {
+        if (item is MenuItem menuItem && string.IsNullOrWhiteSpace(menuItem.Text))
+        {
+            return FormTemplate ?? DefaultTemplate!;
+        }
+        return DefaultTemplate!;
+    }
+}

--- a/MauiDragDrop/Services/MenuLoader.cs
+++ b/MauiDragDrop/Services/MenuLoader.cs
@@ -1,0 +1,21 @@
+using System.Text.Json;
+using MauiDragDrop.Models;
+
+namespace MauiDragDrop.Services;
+
+public static class MenuLoader
+{
+    public static async Task<MenuData> LoadAsync(string path)
+    {
+        await using FileStream stream = File.OpenRead(path);
+        var data = await JsonSerializer.DeserializeAsync<MenuData>(stream) ?? new MenuData();
+        return data;
+    }
+
+    public static async Task SaveAsync(string path, MenuData data)
+    {
+        await using FileStream stream = File.Create(path);
+        var options = new JsonSerializerOptions { WriteIndented = true };
+        await JsonSerializer.SerializeAsync(stream, data, options);
+    }
+}


### PR DESCRIPTION
## Summary
- add Models and Services folders
- implement MenuItem and MenuData classes
- add MenuLoader for loading/saving menu data
- create MenuItemTemplateSelector
- include new source files in project

## Testing
- `dotnet test MauiDragDrop.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886dd2b3b5483329edd8a81e9e4ea5a