### PR TITLE
Add basic Tauri wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # MauiDragDrop
+
+This repository contains a basic .NET MAUI sample demonstrating drag-and-drop functionality. The `tauri` folder includes a minimal Tauri project that can either launch the MAUI application or host a simple web-based drag-and-drop interface.
+
+## Running the MAUI app directly
+
+```bash
+# from the repository root
+dotnet run --project MauiDragDrop
+```
+
+## Using Tauri (desktop bundle)
+
+1. Ensure you have **Rust**, **Cargo**, and **Node.js** installed.
+2. The Tauri project lives in the `tauri` directory. It is configured to run the MAUI project during development and package a small web interface by default.
+
+```bash
+cd tauri
+# build and run in dev mode
+cargo run
+```
+
+When executed, Tauri will run `dotnet run --project ../MauiDragDrop` as specified in `src-tauri/tauri.conf.json` and open a window.
+The `web` folder contains a simple `index.html` used when packaging the app.

--- a/tauri/src-tauri/Cargo.toml
+++ b/tauri/src-tauri/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "maui_dragdrop_tauri"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tauri = { version = "1", features = ["api-all"] }
+
+[build-dependencies]
+tauri-build = { version = "1", features = [] }

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -1,0 +1,5 @@
+fn main() {
+    tauri::Builder::default()
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+}

--- a/tauri/src-tauri/tauri.conf.json
+++ b/tauri/src-tauri/tauri.conf.json
@@ -1,0 +1,21 @@
+{
+  "build": {
+    "beforeDevCommand": "dotnet run --project ../MauiDragDrop",
+    "beforeBuildCommand": "dotnet publish ../MauiDragDrop -c Release",
+    "devPath": "../web",
+    "distDir": "../web"
+  },
+  "package": {
+    "productName": "MauiDragDrop",
+    "version": "0.1.0"
+  },
+  "tauri": {
+    "windows": [
+      {
+        "title": "MauiDragDrop",
+        "width": 800,
+        "height": 600
+      }
+    ]
+  }
+}

--- a/tauri/web/index.html
+++ b/tauri/web/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>Maui DragDrop Web</title>
+<style>
+#drop-area { border: 2px dashed #ccc; padding: 20px; text-align: center; }
+</style>
+</head>
+<body>
+<h1>Drag and Drop Demo</h1>
+<div id="drop-area">Drop files here</div>
+<script>
+const dropArea = document.getElementById('drop-area');
+dropArea.addEventListener('dragover', (e) => {
+  e.preventDefault();
+  dropArea.style.background = '#eee';
+});
+dropArea.addEventListener('dragleave', () => {
+  dropArea.style.background = '';
+});
+dropArea.addEventListener('drop', (e) => {
+  e.preventDefault();
+  const files = Array.from(e.dataTransfer.files).map(f => f.name).join(', ');
+  alert('Dropped: ' + files);
+  dropArea.style.background = '';
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add minimal Tauri project under `tauri`
- configure `tauri.conf.json` to run the MAUI app during dev mode and host a simple web interface
- document how to use the new Tauri project

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886dd2fd8e48332b531b78b375c3aaf