### PR TITLE
Use async file write on menu load

### DIFF
--- a/MauiDragDrop/MainPage.xaml.cs
+++ b/MauiDragDrop/MainPage.xaml.cs
@@ -36,7 +36,7 @@ public partial class MainPage : ContentPage
                 var defaultJson = await FileSystem.OpenAppPackageFileAsync("MenuItems.json");
                 using var reader = new StreamReader(defaultJson);
                 var contents = await reader.ReadToEndAsync();
-                File.WriteAllText(_menuFile, contents);
+                await File.WriteAllTextAsync(_menuFile, contents);
             }
 
             _menuData = await MenuLoader.LoadAsync(_menuFile);


### PR DESCRIPTION
## Summary
- use `File.WriteAllTextAsync` when saving menu on first run

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886e5c19e288332980bb63502ac3683