### PR TITLE
Fix menu paths and model aliasing

### DIFF
--- a/MauiDragDrop/MainPage.xaml.cs
+++ b/MauiDragDrop/MainPage.xaml.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.Maui.Controls.Shapes;
-using MauiDragDrop.Models;
+using Models = MauiDragDrop.Models;
 using MauiDragDrop.Services;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -9,10 +9,10 @@ namespace MauiDragDrop;
 public partial class MainPage : ContentPage
 {
     private BoxView? _dropIndicator;
-    private readonly string _menuFile = Path.Combine(FileSystem.AppDataDirectory, "MenuItems.json");
-    private MenuData _menuData = new();
+    private readonly string _menuFile = System.IO.Path.Combine(FileSystem.AppDataDirectory, "MenuItems.json");
+    private Models.MenuData _menuData = new();
 
-    public ObservableCollection<MenuItem> MenuItems => _menuData.MenuItems;
+    public ObservableCollection<Models.MenuItem> MenuItems => _menuData.MenuItems;
 
     public MainPage()
     {


### PR DESCRIPTION
## Summary
- use `System.IO.Path.Combine` for menu data file
- change `MenuItems` to use the `Models` alias

## Testing
- `dotnet test --no-build` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6886e5bb22f88332a287b17bc7a33eae