### PR TITLE
Remove unnecessary compile includes

### DIFF
--- a/MauiDragDrop/MauiDragDrop.csproj
+++ b/MauiDragDrop/MauiDragDrop.csproj
@@ -10,9 +10,7 @@
 	</PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="Models\**\*.cs" />
-    <Compile Include="Services\**\*.cs" />
-		<!-- Images -->
+                <!-- Images -->
 		<MauiImage Include="Resources\Images\*" />
 		<MauiImage Update="Resources\Images\dotnet_bot.png" Resize="True" BaseSize="300,185" />
 


### PR DESCRIPTION
## Summary
- clean up the csproj by removing explicit compile include statements

## Testing
- `dotnet build` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6886e5ba01b88332a32125493c9beb47