### PR TITLE
Update MainPage xmlns with services prefix

### DIFF
--- a/MauiDragDrop/MainPage.xaml
+++ b/MauiDragDrop/MainPage.xaml
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:services="clr-namespace:MauiDragDrop.Services"
              x:Class="MauiDragDrop.MainPage">
     <ContentPage.Resources>
         <DataTemplate x:Key="DefaultTemplate">
@@ -18,7 +19,7 @@
             </Frame>
         </DataTemplate>
 
-        <local:MenuItemTemplateSelector 
+        <services:MenuItemTemplateSelector
         x:Key="MenuTemplateSelector"
         DefaultTemplate="{StaticResource DefaultTemplate}"
         FormTemplate="{StaticResource FormTemplate}" />


### PR DESCRIPTION
## Summary
- expose `MenuItemTemplateSelector` via `services` XAML namespace
- use the new prefix in `MainPage.xaml`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886e5b915f883328597ac7d91a8135a