### PR TITLE
Fix reorder completed handler

### DIFF
--- a/MauiDragDrop/MainPage.xaml
+++ b/MauiDragDrop/MainPage.xaml
@@ -35,7 +35,7 @@
                 ItemTemplate="{StaticResource MenuTemplateSelector}"
                 ReorderMode="DragAndDrop"
                 CanReorderItems="True"
-                DragReorderCompleted="OnDragReorderCompleted">
+                ReorderCompleted="OnReorderCompleted">
             </CollectionView>
         </VerticalStackLayout>
     </ScrollView>

--- a/MauiDragDrop/MainPage.xaml.cs
+++ b/MauiDragDrop/MainPage.xaml.cs
@@ -108,7 +108,7 @@ public partial class MainPage : ContentPage
         _dropIndicator = null;
     }
 
-    private async void OnDragReorderCompleted(object sender, EventArgs e)
+    private async void OnReorderCompleted(object sender, EventArgs e)
     {
         try
         {


### PR DESCRIPTION
## Summary
- handle reorder completion with `ReorderCompleted`
- update handler name in code-behind

## Testing
- `dotnet build MauiDragDrop.sln -c Release` *(fails: command not found)*
- `dotnet test MauiDragDrop.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886eb06a70883329a61961558e5bdef