### PR TITLE
Update MenuLoader test structure

### DIFF
--- a/MauiDragDrop.Tests/MenuLoaderTests.cs
+++ b/MauiDragDrop.Tests/MenuLoaderTests.cs
@@ -35,11 +35,17 @@ public class MenuLoaderTests
         var path = Path.GetTempFileName();
         var data = new MenuData
         {
-            MenuItems = new ObservableCollection<MenuItem>
+            MenuBar = new ObservableCollection<MenuBar>
             {
-                new MenuItem { Text = "A" },
-                new MenuItem { Text = "B" },
-                new MenuItem { Text = "C" }
+                new MenuBar
+                {
+                    Items = new ObservableCollection<MenuItem>
+                    {
+                        new MenuItem { Text = "A" },
+                        new MenuItem { Text = "B" },
+                        new MenuItem { Text = "C" }
+                    }
+                }
             }
         };
 


### PR DESCRIPTION
## Summary
- adjust test data in `SaveAsync_PersistsReorderedItems` to build a `MenuData` with `MenuBar` items

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886eb051ea0833280aa0588ab1b5719