### PR TITLE
Update target frameworks to .NET 8

### DIFF
--- a/MauiDragDrop.Tests/MauiDragDrop.Tests.csproj
+++ b/MauiDragDrop.Tests/MauiDragDrop.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+  <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/MauiDragDrop.WinUI/MauiDragDrop.WinUI.csproj
+++ b/MauiDragDrop.WinUI/MauiDragDrop.WinUI.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net10.0</TargetFramework>
+<TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
 		<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
 		<RootNamespace>MauiDragDrop.WinUI</RootNamespace>
 		<ApplicationManifest>app.manifest</ApplicationManifest>

--- a/MauiDragDrop/MauiDragDrop.csproj
+++ b/MauiDragDrop/MauiDragDrop.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net10.0</TargetFramework>
+<TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ MauiDragDrop is a sample application exploring drag-and-drop support using .NET 
 2. Run the MAUI app:
 
    ```bash
-   dotnet build MauiDragDrop -t:Run -f net10.0
+   dotnet build MauiDragDrop -t:Run -f net8.0-windows10.0.19041.0
    ```
 
 ## Building the WinUI Project
@@ -26,7 +26,7 @@ MauiDragDrop is a sample application exploring drag-and-drop support using .NET 
 1. Navigate to the WinUI project and build for Windows:
 
    ```bash
-   dotnet build MauiDragDrop.WinUI/MauiDragDrop.WinUI.csproj -f net10.0-windows10.0.19041.0
+   dotnet build MauiDragDrop.WinUI/MauiDragDrop.WinUI.csproj -f net8.0-windows10.0.19041.0
    ```
 
 2. To run the WinUI app, use Visual Studio or the `dotnet run` command with the desired runtime identifier.


### PR DESCRIPTION
## Summary
- target .NET 8 in all project files
- adjust README build commands

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886fd6ffc688332a539ab0ecc496238