### PR TITLE
Fix CS8622 warnings on drag/drop handlers

### DIFF
--- a/MauiDragDrop/MainPage.xaml.cs
+++ b/MauiDragDrop/MainPage.xaml.cs
@@ -72,7 +72,7 @@ public partial class MainPage : ContentPage
         frame.GestureRecognizers.Add(dropGesture);
     }
 
-    private void OnDragStarting(object sender, DragStartingEventArgs e)
+    private void OnDragStarting(object? sender, DragStartingEventArgs e)
     {
         if (sender is Frame frame)
         {
@@ -80,7 +80,7 @@ public partial class MainPage : ContentPage
         }
     }
 
-    private void OnDragOver(object sender, DragEventArgs e)
+    private void OnDragOver(object? sender, DragEventArgs e)
     {
         var layout = (sender as VisualElement)?.Parent as Layout;
         if (layout == null) return;
@@ -102,7 +102,7 @@ public partial class MainPage : ContentPage
         }
     }
 
-    private void OnDrop(object sender, DropEventArgs e)
+    private void OnDrop(object? sender, DropEventArgs e)
     {
         _dropIndicator?.RemoveFromParent();
         _dropIndicator = null;


### PR DESCRIPTION
## Summary
- update drag/drop event handler signatures to accept nullable sender

## Testing
- `dotnet build MauiDragDrop.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688843cc1af483329657234e3815c405